### PR TITLE
Optimize delete lookup and Unicode distance

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ func main() {
 	if !ok {
 		log.Fatal("Не удалось загрузить словарь")
 	}
+	spellChecker.ClearTransformData()
 
 	fmt.Println("Словарь успешно загружен!")
 	fmt.Println("Введите слова для проверки (каждое слово или фразу на отдельной строке).")

--- a/internal/lru.go
+++ b/internal/lru.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"container/list"
+	"symspell/pkg/items"
+)
+
+type topCache struct {
+	capacity int
+	ll       *list.List
+	cache    map[string]*list.Element
+}
+
+type cacheEntry struct {
+	key string
+	val items.SuggestItem
+}
+
+func newTopCache(capacity int) *topCache {
+	return &topCache{
+		capacity: capacity,
+		ll:       list.New(),
+		cache:    make(map[string]*list.Element),
+	}
+}
+
+func (c *topCache) Get(key string) (items.SuggestItem, bool) {
+	if ele, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(cacheEntry).val, true
+	}
+	return items.SuggestItem{}, false
+}
+
+func (c *topCache) Add(key string, val items.SuggestItem) {
+	if ele, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ele)
+		ele.Value = cacheEntry{key: key, val: val}
+		return
+	}
+	ele := c.ll.PushFront(cacheEntry{key: key, val: val})
+	c.cache[key] = ele
+	if c.ll.Len() > c.capacity {
+		if last := c.ll.Back(); last != nil {
+			c.ll.Remove(last)
+			entry := last.Value.(cacheEntry)
+			delete(c.cache, entry.key)
+		}
+	}
+}

--- a/pkg/editdistance/edit_distance.go
+++ b/pkg/editdistance/edit_distance.go
@@ -1,7 +1,13 @@
 package editdistance
 
+import (
+	"sync"
+	"unicode/utf8"
+)
+
 type IEditDistance interface {
 	Distance(a, b string) int
+	DistanceMax(a, b string, maxDistance int) int
 }
 
 func NewEditDistance(Type string) *EditDistance {
@@ -16,10 +22,42 @@ type EditDistance struct {
 	Type string
 }
 
+var intSlicePool = sync.Pool{New: func() any { return make([]int, 0) }}
+
+func getIntSlice(size int) []int {
+	v := intSlicePool.Get()
+	if v == nil {
+		return make([]int, size)
+	}
+	s := v.([]int)
+	if cap(s) < size {
+		return make([]int, size)
+	}
+	return s[:size]
+}
+
+func putIntSlice(s []int) {
+	intSlicePool.Put(s)
+}
+
 func (d EditDistance) Distance(a, b string) int {
 	switch d.Type {
 	case DamerauLevenshtein:
-		return damerauLevenshteinDistance(a, b)
+		if isASCII(a) && isASCII(b) {
+			return damerauLevenshteinDistance(a, b)
+		}
+		return damerauLevenshteinDistanceRunes([]rune(a), []rune(b))
+	}
+	return 0
+}
+
+func (d EditDistance) DistanceMax(a, b string, maxDistance int) int {
+	switch d.Type {
+	case DamerauLevenshtein:
+		if isASCII(a) && isASCII(b) {
+			return damerauLevenshteinDistanceMax(a, b, maxDistance)
+		}
+		return damerauLevenshteinDistanceMaxRunes([]rune(a), []rune(b), maxDistance)
 	}
 	return 0
 }
@@ -35,9 +73,12 @@ func damerauLevenshteinDistance(a, b string) int {
 		return m
 	}
 
-	prev2 := make([]int, n+1)
-	prev := make([]int, n+1)
-	curr := make([]int, n+1)
+	prev2 := getIntSlice(n + 1)
+	prev := getIntSlice(n + 1)
+	curr := getIntSlice(n + 1)
+	defer putIntSlice(prev2)
+	defer putIntSlice(prev)
+	defer putIntSlice(curr)
 
 	for j := 0; j <= n; j++ {
 		prev[j] = j
@@ -66,4 +107,238 @@ func damerauLevenshteinDistance(a, b string) int {
 	}
 
 	return prev[n]
+}
+
+func damerauLevenshteinDistanceMax(a, b string, k int) int {
+	m := len(a)
+	n := len(b)
+
+	if m == 0 {
+		if n <= k {
+			return n
+		}
+		return k + 1
+	}
+	if n == 0 {
+		if m <= k {
+			return m
+		}
+		return k + 1
+	}
+
+	if d := m - n; d > k || d < -k {
+		return k + 1
+	}
+
+	prev2 := getIntSlice(n + 1)
+	prev := getIntSlice(n + 1)
+	curr := getIntSlice(n + 1)
+	defer putIntSlice(prev2)
+	defer putIntSlice(prev)
+	defer putIntSlice(curr)
+
+	limit := k + 1
+	for j := 0; j <= n; j++ {
+		if j <= k {
+			prev[j] = j
+		} else {
+			prev[j] = limit
+		}
+	}
+
+	for i := 1; i <= m; i++ {
+		curr[0] = i
+
+		jStart := 1
+		if i > k {
+			jStart = i - k
+		}
+		jEnd := n
+		if jEnd > i+k {
+			jEnd = i + k
+		}
+
+		if jStart > 1 {
+			curr[jStart-1] = limit
+		}
+
+		rowMin := limit
+		for j := jStart; j <= jEnd; j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			dist := min(del, min(ins, sub))
+			if i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1] {
+				trans := prev2[j-2] + cost
+				if trans < dist {
+					dist = trans
+				}
+			}
+			curr[j] = dist
+			if dist < rowMin {
+				rowMin = dist
+			}
+		}
+		if rowMin > k {
+			return k + 1
+		}
+		if jEnd < n {
+			curr[jEnd+1] = limit
+		}
+		prev2, prev, curr = prev, curr, prev2
+	}
+
+	if prev[n] > k {
+		return k + 1
+	}
+	return prev[n]
+}
+
+func damerauLevenshteinDistanceRunes(a, b []rune) int {
+	m := len(a)
+	n := len(b)
+
+	if m == 0 {
+		return n
+	}
+	if n == 0 {
+		return m
+	}
+
+	prev2 := getIntSlice(n + 1)
+	prev := getIntSlice(n + 1)
+	curr := getIntSlice(n + 1)
+	defer putIntSlice(prev2)
+	defer putIntSlice(prev)
+	defer putIntSlice(curr)
+
+	for j := 0; j <= n; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= m; i++ {
+		curr[0] = i
+		for j := 1; j <= n; j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			dist := min(del, min(ins, sub))
+			if i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1] {
+				trans := prev2[j-2] + cost
+				if trans < dist {
+					dist = trans
+				}
+			}
+			curr[j] = dist
+		}
+		prev2, prev, curr = prev, curr, prev2
+	}
+
+	return prev[n]
+}
+
+func damerauLevenshteinDistanceMaxRunes(a, b []rune, k int) int {
+	m := len(a)
+	n := len(b)
+
+	if m == 0 {
+		if n <= k {
+			return n
+		}
+		return k + 1
+	}
+	if n == 0 {
+		if m <= k {
+			return m
+		}
+		return k + 1
+	}
+
+	if d := m - n; d > k || d < -k {
+		return k + 1
+	}
+
+	prev2 := getIntSlice(n + 1)
+	prev := getIntSlice(n + 1)
+	curr := getIntSlice(n + 1)
+	defer putIntSlice(prev2)
+	defer putIntSlice(prev)
+	defer putIntSlice(curr)
+
+	limit := k + 1
+	for j := 0; j <= n; j++ {
+		if j <= k {
+			prev[j] = j
+		} else {
+			prev[j] = limit
+		}
+	}
+
+	for i := 1; i <= m; i++ {
+		curr[0] = i
+
+		jStart := 1
+		if i > k {
+			jStart = i - k
+		}
+		jEnd := n
+		if jEnd > i+k {
+			jEnd = i + k
+		}
+
+		if jStart > 1 {
+			curr[jStart-1] = limit
+		}
+
+		rowMin := limit
+		for j := jStart; j <= jEnd; j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			dist := min(del, min(ins, sub))
+			if i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1] {
+				trans := prev2[j-2] + cost
+				if trans < dist {
+					dist = trans
+				}
+			}
+			curr[j] = dist
+			if dist < rowMin {
+				rowMin = dist
+			}
+		}
+		if rowMin > k {
+			return k + 1
+		}
+		if jEnd < n {
+			curr[jEnd+1] = limit
+		}
+		prev2, prev, curr = prev, curr, prev2
+	}
+
+	if prev[n] > k {
+		return k + 1
+	}
+	return prev[n]
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/symspell.go
+++ b/pkg/symspell.go
@@ -27,6 +27,7 @@ func NewSymSpellWithLoadDictionary(dirPath string, termIndex, countIndex int, op
 	if !ok {
 		log.Fatal("[Error] loading dictionary has been failed")
 	}
+	symspell.ClearTransformData()
 	return symspell
 }
 


### PR DESCRIPTION
## Summary
- Flatten delete postings into a single array with offset/length index
- Pass dictionary index to updateSuggestions to avoid map lookups
- Add ASCII fast paths for prefix handling and delete generation
- Use map[string]struct{} for candidate tracking sets
- Cache top suggestions in a small LRU to reuse frequent lookups
- Clear optional transform data after dictionary load
- Introduce banded Damerau-Levenshtein with max-distance threshold and pooled buffers
- Parallelize dictionary loading and shard delete generation with faster line parsing
- Switch to rune-based Damerau-Levenshtein for non-ASCII inputs
- Pool candidate processors and perform rune-aware prefix, first-rune, and tail checks in lookup routines
- Measure compound term lengths by runes for Unicode correctness

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ad87a78d5883239d0f27320c5cd1b2